### PR TITLE
chore: Internal GitHub Action migration

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ jobs:
           cache: "npm"
 
       - name: validate github workflow files
-        uses: digitalservicebund/github-actions/github-actions-linter@df6e19d8472c90dd612a8c9497fd22d501e710c0
+        uses: digitalservicebund/github-actions-linter@16aee7d3ea804d707e9faf6ab3f049ef560dded7 # v0.1.11
 
       - uses: ruby/setup-ruby@d37167af451eb51448db3354e1057b75c4b268f7
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ jobs:
           cache: "npm"
 
       - name: validate github workflow files
-        uses: digitalservicebund/github-actions-linter@16aee7d3ea804d707e9faf6ab3f049ef560dded7 # v0.1.11
+        uses: digitalservicebund/github-actions-linter@dccac3ada437947aada4bc901daff08ceb87c3f1 # v0.1.11
 
       - uses: ruby/setup-ruby@d37167af451eb51448db3354e1057b75c4b268f7
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
           cache: "npm"
 
       - name: validate github workflow files
-        uses: digitalservicebund/github-actions/github-actions-linter@df6e19d8472c90dd612a8c9497fd22d501e710c0
+        uses: digitalservicebund/github-actions-linter@16aee7d3ea804d707e9faf6ab3f049ef560dded7 # v0.1.11
 
       - uses: ruby/setup-ruby@d37167af451eb51448db3354e1057b75c4b268f7
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
           cache: "npm"
 
       - name: validate github workflow files
-        uses: digitalservicebund/github-actions-linter@16aee7d3ea804d707e9faf6ab3f049ef560dded7 # v0.1.11
+        uses: digitalservicebund/github-actions-linter@dccac3ada437947aada4bc901daff08ceb87c3f1 # v0.1.11
 
       - uses: ruby/setup-ruby@d37167af451eb51448db3354e1057b75c4b268f7
         with:


### PR DESCRIPTION
As mentioned [here](https://digitalservicebund.slack.com/archives/C03M9TZTDK8/p1710341286056739), we have to split our internal GitHub actions repo. This PR update your CI configuration to point to the new repositories. Please, review and merge this PR. Don't hesitate to contact the Platform team if you run into any issue.